### PR TITLE
Add the new GPT models, including gpt-4 128k

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         run: yarn install --frozen-lockfile
         env:
           CI: '' # suppress treating warnings as errors for now
+          NODE_ENV: production
       - name: 🩻 Test
         run: echo "🧪 No Tests set" #yarn test
       - name: 🏭 Build Project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
         run: yarn install --frozen-lockfile
         env:
           CI: '' # suppress treating warnings as errors for now
-          NODE_ENV: production
       - name: 🩻 Test
         run: echo "🧪 No Tests set" #yarn test
       - name: 🏭 Build Project

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "description": "Play and chat smarter with BetterChatGPT - an amazing open-source web app with a better UI for exploring OpenAI's ChatGPT API!",
   "scripts": {
     "dev": "vite --host",
-    "build": "tsc && vite build --mode $NODE_ENV",
+    "build": "tsc && vite build",
+    "build:dev": "tsc && vite build --mode development",
     "preview": "vite preview",
     "electron": "concurrently -k \"BROWSER=none yarn dev\" \"wait-on tcp:5173 && electron .\"",
     "pack": "yarn build && electron-builder --dir",

--- a/src/components/TokenCount/TokenCount.tsx
+++ b/src/components/TokenCount/TokenCount.tsx
@@ -17,7 +17,7 @@ const TokenCount = React.memo(() => {
   const model = useStore((state) =>
     state.chats
       ? state.chats[state.currentChatIndex].config.model
-      : 'gpt-3.5-turbo'
+      : 'gpt-3.5-turbo-1106'
   );
 
   const cost = useMemo(() => {

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -20,7 +20,9 @@ Respond using Markdown.`;
 export const modelOptions: ModelOptions[] = [
   'gpt-3.5-turbo',
   'gpt-3.5-turbo-16k',
+  'gpt-3.5-turbo-1106',
   'gpt-4',
+  'gpt-4-1106-preview',
   // 'gpt-4-32k',
   // 'gpt-3.5-turbo-0301',
   // 'gpt-4-0314',
@@ -35,12 +37,14 @@ export const modelMaxToken = {
   'gpt-3.5-turbo-0613': 4096,
   'gpt-3.5-turbo-16k': 16384,
   'gpt-3.5-turbo-16k-0613': 16384,
+  'gpt-3.5-turbo-1106': 16384,
   'gpt-4': 8192,
   'gpt-4-0314': 8192,
   'gpt-4-0613': 8192,
   'gpt-4-32k': 32768,
   'gpt-4-32k-0314': 32768,
   'gpt-4-32k-0613': 32768,
+  'gpt-4-1106-preview': 128000,
 };
 
 export const modelCost = {
@@ -64,6 +68,10 @@ export const modelCost = {
     prompt: { price: 0.003, unit: 1000 },
     completion: { price: 0.004, unit: 1000 },
   },
+  'gpt-3.5-turbo-1106': {
+    prompt: { price: 0.001, unit: 1000 },
+    completion: { price: 0.002, unit: 1000 },
+  },
   'gpt-4': {
     prompt: { price: 0.03, unit: 1000 },
     completion: { price: 0.06, unit: 1000 },
@@ -78,15 +86,19 @@ export const modelCost = {
   },
   'gpt-4-32k': {
     prompt: { price: 0.06, unit: 1000 },
-    completion: { price: 0.12, unit: 1000 },
+    completion: { price: 0.012, unit: 1000 },
   },
   'gpt-4-32k-0314': {
     prompt: { price: 0.06, unit: 1000 },
-    completion: { price: 0.12, unit: 1000 },
+    completion: { price: 0.012, unit: 1000 },
   },
   'gpt-4-32k-0613': {
     prompt: { price: 0.06, unit: 1000 },
-    completion: { price: 0.12, unit: 1000 },
+    completion: { price: 0.012, unit: 1000 },
+  },
+  'gpt-4-1106': {
+    prompt: { price: 0.01, unit: 1000 },
+    completion: { price: 0.03, unit: 1000 },
   },
 };
 

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -96,7 +96,7 @@ export const modelCost = {
     prompt: { price: 0.06, unit: 1000 },
     completion: { price: 0.012, unit: 1000 },
   },
-  'gpt-4-1106': {
+  'gpt-4-1106-preview': {
     prompt: { price: 0.01, unit: 1000 },
     completion: { price: 0.03, unit: 1000 },
   },

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -49,7 +49,7 @@ export interface Folder {
   color?: string;
 }
 
-export type ModelOptions = 'gpt-4' | 'gpt-4-32k' | 'gpt-3.5-turbo' | 'gpt-3.5-turbo-16k' ;
+export type ModelOptions = 'gpt-4' | 'gpt-4-32k' | 'gpt-3.5-turbo' | 'gpt-3.5-turbo-16k' | 'gpt-3.5-turbo-1106' | 'gpt-4-1106-preview' ;
 // | 'gpt-3.5-turbo-0301';
 // | 'gpt-4-0314'
 // | 'gpt-4-32k-0314'

--- a/src/utils/messageUtils.ts
+++ b/src/utils/messageUtils.ts
@@ -21,7 +21,7 @@ export const getChatGPTEncoding = (
   messages: MessageInterface[],
   model: ModelOptions
 ) => {
-  const isGpt3 = model === 'gpt-3.5-turbo';
+  const isGpt3 = model.startsWith('gpt-3.5-turbo');
 
   const msgSep = isGpt3 ? '\n' : '';
   const roleSep = isGpt3 ? '\n' : '<|im_sep|>';


### PR DESCRIPTION
## Description

This commit adds new GPT models to the project, specifically gpt-3.5-turbo-1106 and gpt-4-1106-preview, with the latter supporting an impressive 128k token count. The update was made in various files to include these models in the options, token count, and pricing configurations. The motivation for this change is to keep up with the latest advancements in GPT models and provide users with updated and more powerful options for their natural language processing tasks.

## Type of change

- [ ] Release (new release)
- [ ] Hot/Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation (documentation update would be required if applicable)
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings